### PR TITLE
refactor(root): update model to gemini-2.0-flash

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 	RootCmd.Flags().
 		StringVarP(&userContext, "context", "c", "", "additional context to be added to the commit message")
 	RootCmd.Flags().
-		StringVarP(&model, "model", "m", "gemini-1.5-pro", "google gemini model to use")
+		StringVarP(&model, "model", "m", "gemini-2.0-flash", "google gemini model to use")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/delivery/cli/handler/root_handler.go
+++ b/internal/delivery/cli/handler/root_handler.go
@@ -42,7 +42,7 @@ func (r *RootHandler) RootCommand(
 ) func(*cobra.Command, []string) {
 	return func(_ *cobra.Command, _ []string) {
 		modelFromConfig := viper.GetString("api.model")
-		if modelFromConfig != "" && *model == "gemini-1.5-pro" {
+		if modelFromConfig != "" && *model == "gemini-2.0-flash" {
 			*model = modelFromConfig
 		}
 


### PR DESCRIPTION
The previous default (`gemini-1.5-pro`) now returns an error:

```
Error: googleapi: Error 429: You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.
```