### PR TITLE
chore(model): update default gemini model to 2.5-flash

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,7 +88,7 @@ func init() {
 	RootCmd.Flags().
 		StringVarP(&userContext, "context", "c", "", "additional context to be added to the commit message")
 	RootCmd.Flags().
-		StringVarP(&model, "model", "m", "gemini-2.0-flash", "google gemini model to use")
+		StringVarP(&model, "model", "m", "gemini-2.5-flash", "google gemini model to use")
 	RootCmd.Flags().
 		BoolVarP(&dryRun, "dry-run", "d", dryRun, "run the command without making any changes")
 	RootCmd.Flags().

--- a/internal/delivery/cli/handler/root_handler.go
+++ b/internal/delivery/cli/handler/root_handler.go
@@ -49,7 +49,7 @@ func (r *RootHandler) RootCommand(
 ) func(*cobra.Command, []string) {
 	return func(_ *cobra.Command, _ []string) {
 		modelFromConfig := viper.GetString("api.model")
-		if modelFromConfig != "" && *model == "gemini-2.0-flash" {
+		if modelFromConfig != "" && *model == "gemini-2.5-flash" {
 			*model = modelFromConfig
 		}
 


### PR DESCRIPTION
The default model for Gemini API calls is now 'gemini-2.5-flash'. This updates
the flag default and config override logic.
