### PR TITLE
feat(baseurl) Add support for specifying custom base url for gemini api

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,20 +17,21 @@ import (
 )
 
 var (
-	cfgFile     string
-	stageAll    = false
-	userContext string
-	model       string
-	noConfirm   = false
-	quiet       = false
-	push        = false
-	dryRun      = false
-	showDiff    = false
-	maxLength   = 72
-	language    = "english"
-	issue       string
-	noVerify    = false
-	rootHandler = handler.NewRootHandler()
+	cfgFile       string
+	stageAll      = false
+	userContext   string
+	model         string
+	noConfirm     = false
+	quiet         = false
+	push          = false
+	dryRun        = false
+	showDiff      = false
+	maxLength     = 72
+	language      = "english"
+	issue         string
+	noVerify      = false
+	customBaseUrl string
+	rootHandler   = handler.NewRootHandler()
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -55,6 +56,7 @@ var RootCmd = &cobra.Command{
 		&language,
 		&issue,
 		&noVerify,
+		&customBaseUrl,
 	),
 }
 
@@ -101,6 +103,8 @@ func init() {
 		StringVarP(&issue, "issue", "i", "", "issue number or title")
 	RootCmd.Flags().
 		BoolVarP(&noVerify, "no-verify", "v", noVerify, "skip git commit-msg hook verification")
+	RootCmd.Flags().
+		StringVarP(&customBaseUrl, "endpoint", "", customBaseUrl, "specifiy custom endpoint url for Google Gemini Pro API")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 	RootCmd.Flags().
 		BoolVarP(&noVerify, "no-verify", "v", noVerify, "skip git commit-msg hook verification")
 	RootCmd.Flags().
-		StringVarP(&customBaseUrl, "endpoint", "", customBaseUrl, "specifiy custom endpoint url for Google Gemini Pro API")
+		StringVarP(&customBaseUrl, "baseurl", "", customBaseUrl, "specify custom url for Google Gemini Pro API")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/delivery/cli/handler/root_handler.go
+++ b/internal/delivery/cli/handler/root_handler.go
@@ -46,6 +46,7 @@ func (r *RootHandler) RootCommand(
 	language *string,
 	issue *string,
 	noVerify *bool,
+	customBaseUrl *string,
 ) func(*cobra.Command, []string) {
 	return func(_ *cobra.Command, _ []string) {
 		modelFromConfig := viper.GetString("api.model")
@@ -68,7 +69,7 @@ func (r *RootHandler) RootCommand(
 			os.Exit(1)
 		}
 
-		err := r.useCase.RootCommand(ctx, apiKey, stageAll, userContext, model, noConfirm, quiet, push, dryRun, showDiff, maxLength, language, issue, noVerify)
+		err := r.useCase.RootCommand(ctx, apiKey, stageAll, userContext, model, noConfirm, quiet, push, dryRun, showDiff, maxLength, language, issue, noVerify, customBaseUrl)
 		cobra.CheckErr(err)
 	}
 }

--- a/internal/usecase/root_usecase.go
+++ b/internal/usecase/root_usecase.go
@@ -39,12 +39,19 @@ func NewRootUsecase() *RootUsecase {
 	return rootUsecaseInstance
 }
 
-func (r *RootUsecase) initializeGeminiClient(ctx context.Context, apiKey string) (*genai.Client, error) {
+func (r *RootUsecase) initializeGeminiClient(ctx context.Context, apiKey string, customBaseUrl *string) (*genai.Client, error) {
+	baseUrl := ""
+	if customBaseUrl != nil {
+		baseUrl = *customBaseUrl
+	}
 	client, err := genai.NewClient(
 		ctx,
 		&genai.ClientConfig{
 			APIKey:  apiKey,
 			Backend: genai.BackendGeminiAPI,
+			HTTPOptions: genai.HTTPOptions{
+				BaseURL: baseUrl,
+			},
 		},
 	)
 	if err != nil {
@@ -68,9 +75,10 @@ func (r *RootUsecase) RootCommand(
 	language *string,
 	issue *string,
 	noVerify *bool,
+	customBaseUrl *string,
 ) error {
 	// Initialize Gemini client
-	client, err := r.initializeGeminiClient(ctx, apiKey)
+	client, err := r.initializeGeminiClient(ctx, apiKey, customBaseUrl)
 	if err != nil {
 		fmt.Printf("Error getting gemini client: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
Introduces a new flag that allows a custom baseUrl for gemini. this allows users to specify custom endpoint URLs for the Google Gemini Pro API. 